### PR TITLE
Fix crash when stripping whole line comments

### DIFF
--- a/src/main/java/net/minecraftforge/depigifier/MappingFile.java
+++ b/src/main/java/net/minecraftforge/depigifier/MappingFile.java
@@ -39,7 +39,7 @@ public class MappingFile {
                 if (idx == -1) return l;
                 while (idx > 0 && Character.isWhitespace(l.charAt(idx)))
                     idx--;
-                return l.substring(0, idx - 1);
+                return idx > 0 ? l.substring(0, idx - 1) : "";
             })
             .filter(l -> !l.isEmpty())
             .collect(Collectors.toList());


### PR DESCRIPTION
For a whole line comment, the `idx` variable will be 0 meaning that the substring call will produce an IOOB exception.