### PR TITLE
Use bytecode to match lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation('org.slf4j:slf4j-api:1.7.30')
     implementation('org.slf4j:slf4j-simple:1.7.30')
     implementation('org.ow2.asm:asm:9.1')
+    implementation('org.ow2.asm:asm-tree:9.1')
     implementation('net.minecraftforge:srgutils:0.4.3')
 }
 

--- a/src/main/java/net/minecraftforge/depigifier/EditDistance.java
+++ b/src/main/java/net/minecraftforge/depigifier/EditDistance.java
@@ -1,3 +1,22 @@
+/*
+ * DePigifier
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.depigifier;
 
 import org.objectweb.asm.Type;

--- a/src/main/java/net/minecraftforge/depigifier/EditDistance.java
+++ b/src/main/java/net/minecraftforge/depigifier/EditDistance.java
@@ -1,0 +1,70 @@
+package net.minecraftforge.depigifier;
+
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+public class EditDistance {
+	
+	public static double computeDistance(InsnList m, InsnList n, IMapper mapperM, IMapper mapperN) {
+		int[][] matrix = new int[m.size()+1][n.size()+1];
+		//initialise
+		for(int i = 0; i < matrix.length; i++) {
+			matrix[i][0] = i;
+		}
+		for(int j = 0; j < matrix[0].length; j++) {
+			matrix[0][j] = j;
+		}
+		
+		//fill matrix, see: https://en.wikipedia.org/wiki/Levenshtein_distance
+		for(int i = 1; i < matrix.length; i++) {
+			for(int j = 1; j < matrix[0].length; j++) {
+				boolean areEqual = insnEqual(m.get(i-1), n.get(j-1), mapperM, mapperN);
+				int replace = matrix[i-1][j-1] + (areEqual ? 0 : 1);
+				int remove = matrix[i-1][j] + 1;
+				int insert = matrix[i][j-1] + 1;
+				
+				matrix[i][j] = Math.min(Math.min(replace, remove), insert);
+			}
+		}
+		
+		int distance = matrix[m.size()][n.size()];
+		return distance / (double)Math.max(m.size(), n.size());
+	}
+	
+	/**
+	 * Compares two AbstractInsnNodes if they are equal.
+	 */
+	private static boolean insnEqual(AbstractInsnNode a, AbstractInsnNode b, IMapper mapperA, IMapper mapperB) {
+		if(a.getOpcode() != b.getOpcode() || !a.getClass().equals(b.getClass())) {
+			return false;
+		}
+		
+		if(a instanceof FieldInsnNode && b instanceof FieldInsnNode) {
+			FieldInsnNode fieldA = (FieldInsnNode)a;
+			FieldInsnNode fieldB = (FieldInsnNode)b;
+			
+			return Type.getType(fieldA.desc).getSort() == Type.getType(fieldB.desc).getSort();
+		}
+		
+		if(a instanceof MethodInsnNode && b instanceof MethodInsnNode) {
+			MethodInsnNode methodA = (MethodInsnNode)a;
+			MethodInsnNode methodB = (MethodInsnNode)b;
+			
+			return Type.getReturnType(methodA.desc).getSort() == Type.getReturnType(methodB.desc).getSort();
+		}
+		
+		if(a instanceof VarInsnNode && b instanceof VarInsnNode) {
+			VarInsnNode varA = (VarInsnNode)a;
+			VarInsnNode varB = (VarInsnNode)b;
+			
+			return varA.var == varB.var;
+		}
+		
+		return true;
+	}
+
+}

--- a/src/main/java/net/minecraftforge/depigifier/EditDistance.java
+++ b/src/main/java/net/minecraftforge/depigifier/EditDistance.java
@@ -66,14 +66,54 @@ public class EditDistance {
 			FieldInsnNode fieldA = (FieldInsnNode)a;
 			FieldInsnNode fieldB = (FieldInsnNode)b;
 			
-			return Type.getType(fieldA.desc).getSort() == Type.getType(fieldB.desc).getSort();
+			String fieldTypeA = mapperA.mapClass(Type.getType(fieldA.desc).getClassName());
+			String fieldTypeB = mapperB.mapClass(Type.getType(fieldB.desc).getClassName());
+			if(!fieldTypeA.equals(fieldTypeB)) {
+				return false;
+			}
+			
+			String fieldOwnerA = mapperA.mapClass(fieldA.owner);
+			String fieldOwnerB = mapperB.mapClass(fieldB.owner);
+			if(!fieldOwnerA.equals(fieldOwnerB)) {
+				return false;
+			}
+			
+			String fieldNameA = mapperA.mapField(fieldA.owner, fieldA.name);
+			String fieldNameB = mapperB.mapField(fieldB.owner, fieldB.name);
+			if(!fieldNameA.equals(fieldNameB)) {
+				return false;
+			}
+			
+			return true;
 		}
 		
 		if(a instanceof MethodInsnNode && b instanceof MethodInsnNode) {
 			MethodInsnNode methodA = (MethodInsnNode)a;
 			MethodInsnNode methodB = (MethodInsnNode)b;
 			
-			return Type.getReturnType(methodA.desc).getSort() == Type.getReturnType(methodB.desc).getSort();
+			if(methodA.itf != methodB.itf) {
+				return false;
+			}
+			
+			String methodOwnerA = mapperA.mapClass(methodA.owner);
+			String methodOwnerB = mapperB.mapClass(methodB.owner);
+			if(!methodOwnerA.equals(methodOwnerB)) {
+				return false;
+			}
+			
+			String methodDescA = mapperA.mapDescriptor(methodA.desc);
+			String methodDescB = mapperB.mapDescriptor(methodB.desc);
+			if(!methodDescA.equals(methodDescB)) {
+				return false;
+			}
+			
+			String methodNameA = mapperA.mapMethod(methodA.owner, methodA.name, methodA.desc);
+			String methodNameB = mapperB.mapMethod(methodB.owner, methodB.name, methodB.desc);
+			if(!methodNameA.equals(methodNameB)) {
+				return false;
+			}
+			
+			return true;
 		}
 		
 		if(a instanceof VarInsnNode && b instanceof VarInsnNode) {

--- a/src/main/java/net/minecraftforge/depigifier/Matcher.java
+++ b/src/main/java/net/minecraftforge/depigifier/Matcher.java
@@ -315,21 +315,6 @@ public class Matcher {
         		}else {
         			ret.add(methods.get(0).instructions);	
         		}
-        		
-        		cn.methods
-        			.stream()
-        			.map(m -> m.instructions)
-        			.map(insLst -> {
-        				Iterable<AbstractInsnNode> iterable = () -> insLst.iterator();
-        				return StreamSupport.stream(iterable.spliterator(), false);
-        			})
-        			.flatMap(Function.identity())
-        			.filter(ins -> ins instanceof InvokeDynamicInsnNode)
-        			.map(InvokeDynamicInsnNode.class::cast)
-        			.forEach(ins -> {
-        				System.out.println("test"); //actual desc in ins.bdsmArgs[2]
-        			});
-        		
     		}
     	}catch(IOException e) {
     		throw new UncheckedIOException(e);

--- a/src/main/java/net/minecraftforge/depigifier/Matcher.java
+++ b/src/main/java/net/minecraftforge/depigifier/Matcher.java
@@ -330,7 +330,6 @@ public class Matcher {
     	return ret;
     }
 
-
     public void addMapper(final IMapper mapper) {
         mappers.add(mapper);
     }

--- a/src/main/java/net/minecraftforge/depigifier/Matcher.java
+++ b/src/main/java/net/minecraftforge/depigifier/Matcher.java
@@ -198,7 +198,11 @@ public class Matcher {
         Map<String, String> lambdaMappings = new HashMap<>();
         List<Method> lambdasOld = getLambdas(old);
         List<Method> lambdasNew = getLambdas(nw);
-        if(lambdasOld.size() > 1 && lambdasNew.size() > 1) {
+        if(lambdasOld.size() > 0 && lambdasNew.size() > 0) {
+        	// TODO: fix this, if two lambdas swap name, computeLambda is not called, since all names are still present.
+        	// But if we remove the following lines and always call computeLambda we may get an Duplicate key exception,
+        	// because the lambdaMappings contains a mapping, but the value name is an allready existing method name.
+        	// An example would be the lambda 'lambda$fillCrashReportCategory$1()Ljava/lang/String;' in class WorldInfo (1.15.2) / IWorldInfo (1.16.5)
             List<Method> commonForNew = new ArrayList<>();
             List<Method> commonForOld = lambdasOld.stream()
                     .filter(oltMtd ->

--- a/src/main/java/net/minecraftforge/depigifier/Matcher.java
+++ b/src/main/java/net/minecraftforge/depigifier/Matcher.java
@@ -286,7 +286,9 @@ public class Matcher {
     		for(Method mtd : lambdas) {
         		ZipEntry entry = zf.getEntry(mtd.getOwner().getNewName() + ".class");
         		if(entry == null) {
-        			throw new IllegalStateException("Could not find class in jar");
+        			//class stripped?
+        			ret.add(null);
+        			continue;
         		}
         		ClassReader cr = new ClassReader(zf.getInputStream(entry));
         		ClassNode cn = new ClassNode();
@@ -301,7 +303,7 @@ public class Matcher {
         		if(methods.size() > 1) {
         			throw new IllegalStateException("Could not find lambda instructions");	
         		}else if(methods.isEmpty()) {
-        			//method striped?, mostly gametest stuff
+        			//method stripped?, mostly gametest stuff
         			ret.add(null);
         		}else {
         			ret.add(methods.get(0).instructions);	

--- a/src/main/java/net/minecraftforge/depigifier/Matcher.java
+++ b/src/main/java/net/minecraftforge/depigifier/Matcher.java
@@ -215,6 +215,10 @@ public class Matcher {
 				while(old.getMethodSignatures().contains(newName)) {
 					if(lambdaMappings.containsKey(newName)) {
 						newName = lambdaMappings.get(newName);
+						if(newName.equals(mapping.getValue())) {
+							//found a circle
+							break;
+						}
 					}else {
 						collisionResolution.put(mapping.getValue(), "&" + mapping.getValue());
 						break;

--- a/src/main/java/net/minecraftforge/depigifier/Unpig.java
+++ b/src/main/java/net/minecraftforge/depigifier/Unpig.java
@@ -49,8 +49,16 @@ public class Unpig {
                 withRequiredArg().
                 withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
                 required();
+        final ArgumentAcceptingOptionSpec<Path> oldJarFile = optionParser.accepts("oldJar", "Old jar file").
+        		withRequiredArg().
+                withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
+                required();
         final ArgumentAcceptingOptionSpec<Path> newPGFile = optionParser.accepts("newPG", "New ProGuard file").
                 withRequiredArg().
+                withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
+                required();
+        final ArgumentAcceptingOptionSpec<Path> newJarFile = optionParser.accepts("newJar", "New jar file").
+        		withRequiredArg().
                 withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
                 required();
         final ArgumentAcceptingOptionSpec<Path> outDir = optionParser.accepts("out", "Directory to output to").
@@ -76,6 +84,9 @@ public class Unpig {
 
         final Path oldPG = argset.valueOf(oldPGFile);
         final Path newPG = argset.valueOf(newPGFile);
+        
+        final Path oldJar = argset.valueOf(oldJarFile);
+        final Path newJar = argset.valueOf(newJarFile);
         //final Path srgFile = argset.valueOf(inSrgFile);
         final Path output = argset.valueOf(outDir);
         final Path manualMap = argset.valueOf(manualMapFile);
@@ -105,6 +116,6 @@ public class Unpig {
             comp.addMapper(manualMappings);
         }
         comp.computeClassListDifferences();
-        comp.compareExistingClasses();
+        comp.compareExistingClasses(oldJar, newJar);
     }
 }

--- a/src/main/java/net/minecraftforge/depigifier/Unpig.java
+++ b/src/main/java/net/minecraftforge/depigifier/Unpig.java
@@ -92,7 +92,9 @@ public class Unpig {
         final Path manualMap = argset.valueOf(manualMapFile);
 
         final Tree oldTree = Tree.from(IMappingFile.load(oldPG.toFile()), true);
+        final Tree oldTreeReversed = Tree.from(IMappingFile.load(oldPG.toFile()).reverse(), true);
         final Tree newTree = Tree.from(IMappingFile.load(newPG.toFile()), true);
+        final Tree newTreeReversed = Tree.from(IMappingFile.load(newPG.toFile()).reverse(), true);
         /*
         if (argset.has(inSrgFile)) {
             final TSRGFile tsrgFile = new TSRGFile(srgFile, oldProguard);
@@ -109,7 +111,7 @@ public class Unpig {
             }
         }
 
-        Matcher comp = new Matcher(oldTree, newTree, output);
+        Matcher comp = new Matcher(oldTree, oldTreeReversed, newTree, newTreeReversed, output);
 
         if (argset.has(manualMapFile)) {
             final Tree manualMappings = Tree.from(IMappingFile.load(manualMap.toFile()), false);

--- a/src/main/java/net/minecraftforge/depigifier/Unpig.java
+++ b/src/main/java/net/minecraftforge/depigifier/Unpig.java
@@ -50,7 +50,7 @@ public class Unpig {
                 withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
                 required();
         final ArgumentAcceptingOptionSpec<Path> oldJarFile = optionParser.accepts("oldJar", "Old jar file").
-        		withRequiredArg().
+                withRequiredArg().
                 withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
                 required();
         final ArgumentAcceptingOptionSpec<Path> newPGFile = optionParser.accepts("newPG", "New ProGuard file").
@@ -58,7 +58,7 @@ public class Unpig {
                 withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
                 required();
         final ArgumentAcceptingOptionSpec<Path> newJarFile = optionParser.accepts("newJar", "New jar file").
-        		withRequiredArg().
+                withRequiredArg().
                 withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE)).
                 required();
         final ArgumentAcceptingOptionSpec<Path> outDir = optionParser.accepts("out", "Directory to output to").


### PR DESCRIPTION
This PR adds a lambda matcher that uses the bytecode instructions to compare and match lambdas between Minecraft versions. This PR is based on PR #2.
It uses the [levenshein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) to compare two lambdas by computing a value between 0 and 1, indicating how similar the two given lambdas are. A value of 0 means the two lambdas are identical.

I have also added two new required arguments `--oldJar` and `--newJar` that specify the new and old version jars (similar how `--oldPG` and `--newPG` works).

I tested this PR with an 1.15.2 -> 1.16.5 update. The diff between the master branch generated `oldtonew.tsrg` and the `oldtonew.tsrg` generated by this PR consist of 455 insertions and 91 deletions. [oldtonew diff with some comments](https://gist.github.com/Bricktricker/a96ca7d0c94a254e32bd32fb03876fe0)
I have looked at a few of these changes and while most of them are wrong (they have a diffrent srg id in 1.15.2 vs 1.16.5) I still think the mappings are correct and theses are just some human errors. 

### Matching requirements
Currently the requirements for matching two lambdas are that they need to have the same return type and need a similarity value of <= 0.15. This causes some lambdas to be matched that have different argument types like `func_226305_a_`(1.15.2) => `func_233550_a_`(1.16.5). Here the first argument changed from a `DimensionType` to a `ResourceKey`. Is it still correct to match these or should I also check the argument types?

### Overlapping lambdas
Currently (and in PR #2) if there are two lambdas with the same name in the old version and the new version they always get matched. Because this isn't always right this PR uses the lambda distance computation to compare all lambdas. Sometimes this causes problems when we find a mapping `lambda$null$1 -> lambda$null$5`, but a lambda with the name `lambda$null$5` already exists in the old version. This would cause a `DuplicateKeyException` to be thrown [here](https://github.com/MinecraftForge/DePigifier/blob/2bc51645f74c2ae18ac29bf4cf7501316b87b76b/src/main/java/net/minecraftforge/depigifier/Matcher.java#L158). My current workaround for this is to also map the offending lambda to a non existing lambda: `lambda$null$5 -> &lambda$null$5` and then later filter out all methods starting with `&` to not disturb the missing methods stats. Is this the correct way of handling this or is there a better way?

I also had to add the ASM-tree dependency.